### PR TITLE
Update readme to use HTTPS instead of git protocol

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -8,7 +8,7 @@ To get started with Android/LineageOS, you'll need to get familiar with [Source 
 
 To initialize your local repository using the LineageOS trees, use a command like this:
 ```
-repo init -u git://github.com/LineageOS/android.git -b lineage-19.0
+repo init -u https://github.com/LineageOS/android.git -b lineage-19.0
 ```
 Then to sync up:
 ```


### PR DESCRIPTION
GitHub disabled the git protocol as of Jan 11, 2022
See https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Change-Id: Ic50ed9156aae6a76935243ddd7d942f3a0e18d8a